### PR TITLE
fix: Remove stylesheet link from asset manifest

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../images
 //= link_tree ../builds
-//= link_directory ../stylesheets .css


### PR DESCRIPTION
## Summary
- Removes the `//= link_directory ../stylesheets .css` line from the asset manifest

## Test plan
- [ ] Verify assets still load correctly in development and production

🤖 Generated with [Claude Code](https://claude.com/claude-code)