### PR TITLE
fix: Re-add application.css to asset manifest

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link application.css


### PR DESCRIPTION
## Summary

- Re-adds `//= link application.css` to `app/assets/config/manifest.js`
- Sprockets requires this declaration to compile and serve `application.scss` in production/test environments
- Without it, any page render throws `AssetNotPrecompiledError` for `application.css`

This was accidentally removed in PR #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)