### PR TITLE
feat: Editable estimate field pre-filled with highest vote

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -45,8 +45,7 @@ class StoriesController < ApplicationController
   end
 
   def accept_estimate
-    players_voted = @game.games_players.players_voted
-    @story.update!(status: 'estimated', estimate: compute_estimate(players_voted))
+    @story.update!(status: 'estimated', estimate: params[:estimate].presence&.to_d)
 
     @game.games_players.update_all(complexity: nil, amount_of_work: nil, unknown_risk: nil)
 
@@ -91,9 +90,4 @@ class StoriesController < ApplicationController
     params.require(:story).permit(:issue_key, :description, :position)
   end
 
-  def compute_estimate(players_voted)
-    return nil if players_voted.blank?
-    avg = players_voted.sum(&:fibonacci_vote).to_d / players_voted.count
-    GamesPlayer::FIB_ARRAY.min_by { |f| (f - avg).abs }
-  end
 end

--- a/app/views/games/_stories_panel.haml
+++ b/app/views/games/_stories_panel.haml
@@ -17,11 +17,9 @@
         %p.card-text= active_story.description
       - if game.games_players.any? && game.games_players.players_all_voted?
         .d-flex.align-items-center.gap-2.mt-2
-          = button_to "Accept Estimate",
-              accept_estimate_game_story_path(game, active_story),
-              method: :post,
-              data: { turbo_stream: true },
-              class: "btn btn-success btn-sm"
+          = form_with url: accept_estimate_game_story_path(game, active_story), method: :post, data: { turbo_stream: true }, class: "d-flex align-items-center gap-2" do |f|
+            = f.number_field :estimate, value: game.games_players.highest_voter&.fibonacci_vote, step: "any", min: "0", class: "form-control form-control-sm", style: "width: 90px"
+            = f.submit "Accept Estimate", class: "btn btn-success btn-sm"
           = button_to "Re-vote",
               clear_votes_game_path(game),
               method: :post,


### PR DESCRIPTION
## Summary

- When all players have voted, the "Accept Estimate" button is replaced with an inline form containing a number input pre-filled with the highest voter's Fibonacci vote
- The user can edit the value before submitting — the input value is what gets stored, not a computed average
- Removes the `compute_estimate` averaging method from `StoriesController`

## Test plan

- [x] `accept_estimate` stores the submitted estimate value
- [x] `accept_estimate` stores a user-overridden estimate
- [x] `accept_estimate` marks story as estimated and clears votes
- [x] `accept_estimate` auto-advances to the next pending story
- [x] `accept_estimate` with no estimate param saves nil
- [ ] Manual: all players vote → number input appears pre-filled with highest Fibonacci vote
- [ ] Manual: edit the number and accept → session log shows the overridden value

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)