### PR TITLE
chore: pin toolchain with mise and add dev tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ It's not very pretty and I knocked this out as quickly as possible but it does w
 
 **Getting it running**
 
-Nothing special, it's a stock standard rails application.
+Nothing special, it's a stock standard rails application. Toolchain versions (Ruby, Node) are pinned in `mise.toml` and installed via [mise](https://mise.jdx.dev/).
+
 1. Clone the git repository
-2. Install dependencies:
-   - `bundle install` (Ruby gems)
-   - `npm install` (JavaScript dependencies including Bootstrap)
-3. Set up the database: `rails db:create db:migrate`
-4. Start the application: `bin/dev` (runs both Rails server and JavaScript build watcher)
+2. Install [mise](https://mise.jdx.dev/getting-started.html) if you don't already have it
+3. Install all dependencies:
+   - `mise install` — installs Ruby and Node at the pinned versions, then runs `bundle install` and `npm install` automatically via the project's `postinstall` hook
+4. Set up the database: `mise run create-db` (creates, migrates and seeds the database)
+5. Start the application: `mise run dev` (runs both Rails server and JavaScript build watcher via `bin/dev`)
 
 **Using the application**
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,14 @@
+[tools]
+ruby = "3.4.1"
+node = "lts"
+
+[hooks]
+postinstall = "bundle install && npm install"
+
+[tasks.create-db]
+description = "Create, migrate and seed the database"
+run = "rails db:create db:migrate db:seed"
+
+[tasks.dev]
+description = "Start the Rails server and JS build watcher"
+run = "bin/dev"


### PR DESCRIPTION
## Summary
- Adds `mise.toml` pinning Ruby (3.4.1, matching `.ruby-version`) and Node (lts).
- `postinstall` hook runs `bundle install && npm install`, so a fresh checkout bootstraps with a single `mise install`.
- Adds `mise run create-db` (`rails db:create db:migrate db:seed`) and `mise run dev` (wraps `bin/dev`).
- Updates README setup steps to use the mise commands.

## Test plan
- [ ] On a fresh clone (or `rm -rf node_modules`), run `mise install` and confirm Ruby/Node are installed and `bundle install` + `npm install` run automatically.
- [ ] `mise run create-db` creates and migrates the dev database.
- [ ] `mise run dev` starts both Rails and the esbuild watcher and the app loads.