### PR TITLE
feat: show level definitions when sizing a ticket

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,6 +3,7 @@ import * as ActiveStorage from "@rails/activestorage"
 import * as bootstrap from "bootstrap"
 import "./channels/consumer"
 import "./channels/game_channel"
+import "./sizing_definitions"
 
 document.addEventListener('turbo:load', () => {
   var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/app/javascript/sizing_definitions.js
+++ b/app/javascript/sizing_definitions.js
@@ -1,0 +1,51 @@
+function loadDefinitions() {
+  const el = document.querySelector('#sizing-definitions-data');
+  if (!el) return {};
+  try {
+    return JSON.parse(el.textContent);
+  } catch (e) {
+    return {};
+  }
+}
+
+function panelFor(category) {
+  return document.querySelector(`[data-sizing-panel="${category}"]`);
+}
+
+function levelLabel(level) {
+  return level.replace(/_/g, ' ').replace(/^./, (c) => c.toUpperCase());
+}
+
+function renderPanel(category, level) {
+  const panel = panelFor(category);
+  if (!panel) return;
+
+  const definitions = loadDefinitions();
+  const description = level && definitions[category]?.[level];
+
+  if (!description) {
+    panel.innerHTML = '<em class="text-muted">Pick a value to see what it means.</em>';
+    return;
+  }
+
+  const strong = document.createElement('strong');
+  strong.textContent = levelLabel(level);
+  panel.replaceChildren(strong, document.createTextNode(` — ${description}`));
+}
+
+function handleChange(event) {
+  const select = event.target;
+  if (!select.matches?.('select[data-sizing-select]')) return;
+
+  const option = select.options[select.selectedIndex];
+  renderPanel(select.dataset.sizingSelect, option?.dataset.sizingLevel);
+}
+
+document.addEventListener('change', handleChange);
+
+document.addEventListener('turbo:load', () => {
+  document.querySelectorAll('select[data-sizing-select]').forEach((select) => {
+    const option = select.options[select.selectedIndex];
+    renderPanel(select.dataset.sizingSelect, option?.dataset.sizingLevel);
+  });
+});

--- a/app/lib/sizing_definitions.rb
+++ b/app/lib/sizing_definitions.rb
@@ -1,0 +1,30 @@
+module SizingDefinitions
+  PATH = Rails.root.join("config", "sizing_definitions.yml")
+
+  CATEGORIES = %i[complexity amount_of_work unknown_risk].freeze
+
+  class << self
+    def all
+      @all ||= load!
+    end
+
+    def for(category, level)
+      levels(category)[level.to_sym]
+    end
+
+    def levels(category)
+      all.fetch(category.to_sym, {})
+    end
+
+    def reload!
+      @all = nil
+      all
+    end
+
+    private
+
+    def load!
+      YAML.safe_load_file(PATH).deep_symbolize_keys
+    end
+  end
+end

--- a/app/models/amount_of_work.rb
+++ b/app/models/amount_of_work.rb
@@ -1,4 +1,5 @@
 class AmountOfWork < ApplicationRecord
+  LEVELS = %w[tiny little fair large huge].freeze
 
   def to_s
     "tiny (#{tiny}) | little (#{little}) | fair (#{fair}) | large (#{large}) | huge (#{huge})"
@@ -6,5 +7,15 @@ class AmountOfWork < ApplicationRecord
 
   def lookup
     [["tiny (#{tiny})",tiny],["little (#{little})",little],["fair (#{fair})",fair],["large (#{large})",large],["huge (#{huge})",huge]]
+  end
+
+  def lookup_with_keys
+    LEVELS.map { |level| [label_for(level), public_send(level), level] }
+  end
+
+  private
+
+  def label_for(level)
+    "#{level} (#{public_send(level)})"
   end
 end

--- a/app/models/complexity.rb
+++ b/app/models/complexity.rb
@@ -1,4 +1,5 @@
 class Complexity < ApplicationRecord
+  LEVELS = %w[none little fair complex very_complex].freeze
 
   def to_s
     "none (#{none}) | little (#{little}) | fair (#{fair}) | complex (#{complex}) | very_complex (#{very_complex})"
@@ -6,5 +7,15 @@ class Complexity < ApplicationRecord
 
   def lookup
     [["none (#{none})",none],["little (#{little})",little],["fair (#{fair})",fair],["complex (#{complex})",complex],["very complex (#{very_complex})",very_complex]]
+  end
+
+  def lookup_with_keys
+    LEVELS.map { |level| [label_for(level), public_send(level), level] }
+  end
+
+  private
+
+  def label_for(level)
+    "#{level.tr('_', ' ')} (#{public_send(level)})"
   end
 end

--- a/app/models/unknown_risk.rb
+++ b/app/models/unknown_risk.rb
@@ -1,4 +1,5 @@
 class UnknownRisk < ApplicationRecord
+  LEVELS = %w[none low some many].freeze
 
   def to_s
     "none (#{none}) | low (#{low}) | some (#{some}) | many (#{many})"
@@ -6,5 +7,15 @@ class UnknownRisk < ApplicationRecord
 
   def lookup
     [["none (#{none})",none],["low (#{low})",low],["some (#{some})",some],["many (#{many})",many]]
+  end
+
+  def lookup_with_keys
+    LEVELS.map { |level| [label_for(level), public_send(level), level] }
+  end
+
+  private
+
+  def label_for(level)
+    "#{level} (#{public_send(level)})"
   end
 end

--- a/app/views/games/_form_vote.haml
+++ b/app/views/games/_form_vote.haml
@@ -4,11 +4,7 @@
 %script#sizing-definitions-data{ type: 'application/json' }
   != SizingDefinitions.all.to_json
 
-- sizing_categories = [
-  [:complexity,     'Complexity',      @game.complexity],
-  [:amount_of_work, 'Amount of work',  @game.amount_of_work],
-  [:unknown_risk,   'Unknowns / Risks', @game.unknown_risk]
-]
+- sizing_categories = [[:complexity, 'Complexity', @game.complexity], [:amount_of_work, 'Amount of work', @game.amount_of_work], [:unknown_risk, 'Unknowns / Risks', @game.unknown_risk]]
 
 = simple_form_for @games_player, :url => player_vote_game_path(@game), :method => :post, :remote => true, :wrapper => :horizontal_form do |f|
   - sizing_categories.each do |category, label, record|

--- a/app/views/games/_form_vote.haml
+++ b/app/views/games/_form_vote.haml
@@ -1,11 +1,34 @@
 %h6
   #{@games_player.name}
+
+%script#sizing-definitions-data{ type: 'application/json' }
+  != SizingDefinitions.all.to_json
+
+- sizing_categories = [
+  [:complexity,     'Complexity',      @game.complexity],
+  [:amount_of_work, 'Amount of work',  @game.amount_of_work],
+  [:unknown_risk,   'Unknowns / Risks', @game.unknown_risk]
+]
+
 = simple_form_for @games_player, :url => player_vote_game_path(@game), :method => :post, :remote => true, :wrapper => :horizontal_form do |f|
-  = f.input :complexity, collection: @game.complexity.lookup
-  = f.input :amount_of_work, collection: @game.amount_of_work.lookup
-  = f.input :unknown_risk, collection: @game.unknown_risk.lookup
+  - sizing_categories.each do |category, label, record|
+    - options = record.lookup_with_keys.map { |opt_label, value, level| [opt_label, value, { 'data-sizing-level' => level }] }
+    - selected_value = @games_player.public_send(category)
+    - selected_level = record.class::LEVELS.find { |l| record.public_send(l) == selected_value }
+    .form-group.row.mb-2{ data: { sizing_group: category } }
+      = f.label category, label, class: 'col-sm-3 col-form-label'
+      .col-sm-9
+        = f.select category, options_for_select(options, selected_value), { include_blank: true }, { class: 'form-control', data: { sizing_select: category } }
+        .form-text.sizing-description.mt-1{ data: { sizing_panel: category } }
+          - if selected_level
+            %strong= selected_level.tr('_', ' ').capitalize
+            \&nbsp;—
+            = SizingDefinitions.for(category, selected_level)
+          - else
+            %em.text-muted Pick a value to see what it means.
   = f.hidden_field :name
-  = f.submit 'vote',:class => "btn btn-primary"
+  = f.submit 'vote', :class => "btn btn-primary"
+
 %p
   = simple_form_for @games_player, :url => clear_votes_game_path(@game), :method => :post, :remote => true do |f|
     = f.submit 'clear votes',:class => "btn btn-secondary"

--- a/config/sizing_definitions.yml
+++ b/config/sizing_definitions.yml
@@ -1,0 +1,19 @@
+complexity:
+  none: "You understand exactly what to do and there is nothing complex about it. No real explanation needed by the Product Owner. No questions."
+  little: "You understand what to do but there is a bit of complexity. Functionally well specified and understood — there might be a few questions but they're easily explained by the PO. Technically there's a known existing pattern in place; nothing new, just plug it in."
+  fair: "You understand what to do but there is some complex logic. Functionally mostly understood — questions are likely and the spec may need clarification. Technically something new (e.g. adjusting an existing pattern with new ideas), may need investigation, touches a more complex or risky/core area of the code."
+  complex: "You don't fully understand what to do and there is complex logic. Functionally new and not easy for the PO to explain in 10 minutes — many cases, settings, inputs and outputs; probably needs better specification with examples. Technically new, touches a very complex or brittle/untested part of the system, may require changes across multiple services or new infrastructure, with performance considerations."
+  very_complex: "Functionally complex AND technically complex."
+
+amount_of_work:
+  tiny: "Almost not worth talking about. Estimate no more than 30 minutes. No functional impact — e.g. changing a label on a screen, updating docs."
+  little: "Localized changes and impacts; existing ways to test; minimal or no setup. Estimate no more than 1 day. QA: testing a single screen / one import / a single calculation change. Technical: changing a single project or file."
+  fair: "New functionality or broader changes and impacts; probably requires some setup or data. Estimate no more than 3 days. QA: testing smaller new functionality, multiple parts of existing functionality, checking and updating regression cases. Technical: adding new functionality following existing patterns, changing multiple projects or services, performance optimisation."
+  large: "Large new functionality or significant reworking of existing functionality. Estimate no more than 5 days. QA: testing large new functionality (screens, imports, calcs etc.), large number of test cases to write/setup, adding new regression cases. Technical: adding large new functionality, possibly involving new projects/services, significant changes to existing services, performance optimisation."
+  huge: "Too hard to estimate — an indication that this should be broken down into smaller tasks."
+
+unknown_risk:
+  none: "No foreseen impact on the work involved."
+  low: "There is a chance of unknowns or risks impacting the work. Functionally the spec may look light on detail, or it's detailed but large enough that things will surface during implementation. Technically (suspect one of the following): low unit test coverage, unfamiliar code or service, possible performance concerns."
+  some: "There are definite unknowns or risks. At least one of the 'Low' examples is in play, or one of these: spec isn't detailed enough, a new service is being used, the technical approach is unclear, research is required to pick a 3rd-party component."
+  many: "Many of the above examples are in play."

--- a/test/lib/sizing_definitions_test.rb
+++ b/test/lib/sizing_definitions_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class SizingDefinitionsTest < ActiveSupport::TestCase
+  setup { SizingDefinitions.reload! }
+
+  test "exposes all three categories" do
+    assert_equal %i[complexity amount_of_work unknown_risk].sort,
+                 SizingDefinitions.all.keys.sort
+  end
+
+  test "looks up a definition by category and level" do
+    description = SizingDefinitions.for(:complexity, :fair)
+    assert_kind_of String, description
+    assert_match(/some complex logic/i, description)
+  end
+
+  test "accepts string keys" do
+    assert_equal SizingDefinitions.for(:amount_of_work, :tiny),
+                 SizingDefinitions.for("amount_of_work", "tiny")
+  end
+
+  test "returns nil for unknown level" do
+    assert_nil SizingDefinitions.for(:complexity, :nonexistent)
+  end
+
+  test "returns empty hash for unknown category" do
+    assert_equal({}, SizingDefinitions.levels(:nonexistent))
+  end
+
+  test "every model level has a definition" do
+    {
+      complexity: Complexity::LEVELS,
+      amount_of_work: AmountOfWork::LEVELS,
+      unknown_risk: UnknownRisk::LEVELS
+    }.each do |category, levels|
+      levels.each do |level|
+        assert SizingDefinitions.for(category, level).present?,
+               "missing definition for #{category}/#{level}"
+      end
+    end
+  end
+end

--- a/test/models/amount_of_work_test.rb
+++ b/test/models/amount_of_work_test.rb
@@ -1,7 +1,14 @@
 require "test_helper"
 
 class AmountOfWorkTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "lookup_with_keys returns label, value and level for each level" do
+    record = AmountOfWork.new(tiny: 0.5, little: 1, fair: 3, large: 5, huge: 13)
+    triples = record.lookup_with_keys
+
+    assert_equal AmountOfWork::LEVELS.size, triples.size
+    assert_equal "tiny (0.5)", triples.first[0]
+    assert_equal BigDecimal("0.5"), triples.first[1]
+    assert_equal "tiny", triples.first[2]
+    assert_equal AmountOfWork::LEVELS, triples.map(&:last)
+  end
 end

--- a/test/models/complexity_test.rb
+++ b/test/models/complexity_test.rb
@@ -1,7 +1,15 @@
 require "test_helper"
 
 class ComplexityTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "lookup_with_keys returns label, value and level for each level" do
+    record = Complexity.new(none: 1, little: 2, fair: 3, complex: 5, very_complex: 8)
+    triples = record.lookup_with_keys
+
+    assert_equal Complexity::LEVELS.size, triples.size
+    assert_equal "none (1.0)", triples.first[0]
+    assert_equal BigDecimal("1"), triples.first[1]
+    assert_equal "none", triples.first[2]
+    assert_equal "very complex", triples.last[0].split(" (").first
+    assert_equal Complexity::LEVELS, triples.map(&:last)
+  end
 end

--- a/test/models/unknown_risk_test.rb
+++ b/test/models/unknown_risk_test.rb
@@ -1,7 +1,14 @@
 require "test_helper"
 
 class UnknownRiskTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "lookup_with_keys returns label, value and level for each level" do
+    record = UnknownRisk.new(none: 0, low: 1, some: 2, many: 5)
+    triples = record.lookup_with_keys
+
+    assert_equal UnknownRisk::LEVELS.size, triples.size
+    assert_equal "none (0.0)", triples.first[0]
+    assert_equal BigDecimal("0"), triples.first[1]
+    assert_equal "none", triples.first[2]
+    assert_equal UnknownRisk::LEVELS, triples.map(&:last)
+  end
 end


### PR DESCRIPTION
## Summary
- Adds inline definitions for the three sizing dimensions (Complexity, Amount of work, Unknowns/Risks). When a player picks a level in any dropdown, a description panel below it updates with the wiki-derived definition for that level.
- Definitions are stored locally in `config/sizing_definitions.yml` (single source of truth) and exposed to the client via a `<script type="application/json">` blob — no Confluence runtime call.
- New `SizingDefinitions` lookup module + `lookup_with_keys` on each of the three category models so option `<select>`s can carry per-option `data-sizing-level` attributes.
- Vanilla JS handler (no Stimulus, matching existing patterns) updates the panel on `change` and `turbo:load`.

## Test plan
- [ ] `bin/rails test test/lib test/models` passes (9 new tests covering the lookup module + `lookup_with_keys` on each model).
- [ ] In the browser, join a game and verify each of the three dropdowns shows its definition panel as you select a level.
- [ ] Verify the placeholder ("Pick a value to see what it means.") shows when no level is selected.
- [ ] Verify voting still posts correctly and the players table updates as before.
- [ ] Reload after voting to confirm the previously-selected level's description is shown on initial render.