### PR TITLE
feat: write accepted estimate back to jira story points

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -49,6 +49,8 @@ class StoriesController < ApplicationController
 
     @story.update!(status: 'estimated', estimate: params[:estimate].presence&.to_d)
 
+    JiraClient.update_story_points(@story.issue_key, @story.estimate) if @story.estimate
+
     @game.games_players.update_all(complexity: nil, amount_of_work: nil, unknown_risk: nil)
 
     next_story = @game.stories.pending.first

--- a/app/lib/jira_client.rb
+++ b/app/lib/jira_client.rb
@@ -8,6 +8,7 @@ module JiraClient
     :acceptance_criteria_present,
     :technical_review_present,
     :qa_review_present,
+    :story_points_field_id,
     :found,
     keyword_init: true
   ) do
@@ -25,6 +26,9 @@ module JiraClient
     technical_review_present:    "technical review",
     qa_review_present:           "qa review"
   }.freeze
+
+  # Jira Cloud uses "Story Points"; newer instances/teams use "Story point estimate".
+  STORY_POINTS_FIELD_NAMES = ["story points", "story point estimate"].freeze
 
   class << self
     def configured?
@@ -55,6 +59,26 @@ module JiraClient
       nil
     end
 
+    def update_story_points(issue_key, points)
+      return unless configured? && issue_key.present? && points.present?
+
+      field_id = issue(issue_key).story_points_field_id
+      unless field_id
+        Rails.logger.warn("JiraClient.update_story_points: no Story Points field discovered for #{issue_key}")
+        return
+      end
+
+      payload = { fields: { field_id => points.to_f } }.to_json
+      response = perform_request(:put, "/rest/api/3/issue/#{issue_key}", body: payload, content_type: "application/json")
+      unless response.is_a?(Net::HTTPSuccess)
+        Rails.logger.warn("JiraClient.update_story_points got #{response.code} for #{issue_key}: #{response.body}")
+      end
+      response
+    rescue => e
+      Rails.logger.warn("JiraClient.update_story_points failed for #{issue_key}: #{e.class}: #{e.message}")
+      nil
+    end
+
     private
 
     def fetch_issue(issue_key)
@@ -70,7 +94,8 @@ module JiraClient
         summary: fields["summary"],
         acceptance_criteria_present: field_present_by_name?(names, fields, FIELD_LABELS[:acceptance_criteria_present]),
         technical_review_present:    field_present_by_name?(names, fields, FIELD_LABELS[:technical_review_present]),
-        qa_review_present:           field_present_by_name?(names, fields, FIELD_LABELS[:qa_review_present])
+        qa_review_present:           field_present_by_name?(names, fields, FIELD_LABELS[:qa_review_present]),
+        story_points_field_id:       find_field_id_by_names(names, STORY_POINTS_FIELD_NAMES)
       )
     rescue => e
       Rails.logger.warn("JiraClient.fetch_issue failed for #{issue_key}: #{e.class}: #{e.message}")
@@ -78,11 +103,15 @@ module JiraClient
     end
 
     def field_present_by_name?(names, fields, label)
-      target = label.downcase
-      id, _ = names.find { |_, n| n.to_s.downcase == target }
+      id = find_field_id_by_names(names, [label])
       return false unless id
-      value = fields[id]
-      !blank_value?(value)
+      !blank_value?(fields[id])
+    end
+
+    def find_field_id_by_names(names, candidates)
+      targets = candidates.map { |c| c.to_s.downcase }
+      id, _ = names.find { |_, n| targets.include?(n.to_s.downcase) }
+      id
     end
 
     def blank_value?(value)
@@ -98,7 +127,12 @@ module JiraClient
       http.open_timeout = 5
       http.read_timeout = 10
 
-      request_class = method == :get ? Net::HTTP::Get : Net::HTTP::Post
+      request_class = case method
+                      when :get  then Net::HTTP::Get
+                      when :put  then Net::HTTP::Put
+                      when :post then Net::HTTP::Post
+                      else raise ArgumentError, "unsupported method #{method.inspect}"
+                      end
       request = request_class.new(uri.request_uri)
       request.basic_auth(email, token)
       request["Accept"] = "application/json"

--- a/test/lib/jira_client_test.rb
+++ b/test/lib/jira_client_test.rb
@@ -37,12 +37,14 @@ class JiraClientTest < ActiveSupport::TestCase
     body = {
       "names" => {
         "summary" => "Summary",
+        "customfield_10016" => "Story Points",
         "customfield_10100" => "Acceptance Criteria",
         "customfield_10101" => "Technical Review",
         "customfield_10102" => "QA Review"
       },
       "fields" => {
         "summary" => "Build the thing",
+        "customfield_10016" => 3.0,
         "customfield_10100" => "Given/When/Then…",
         "customfield_10101" => nil,
         "customfield_10102" => ""
@@ -56,6 +58,18 @@ class JiraClientTest < ActiveSupport::TestCase
       assert result.acceptance_criteria_present
       refute result.technical_review_present
       refute result.qa_review_present
+      assert_equal "customfield_10016", result.story_points_field_id
+    end
+  end
+
+  test "issue discovers the story points field under the new 'Story point estimate' name" do
+    body = {
+      "names" => { "customfield_10020" => "Story point estimate" },
+      "fields" => { "customfield_10020" => nil }
+    }.to_json
+
+    stub_http_response(Net::HTTPSuccess, body: body) do
+      assert_equal "customfield_10020", JiraClient.issue("ABC-1").story_points_field_id
     end
   end
 
@@ -101,6 +115,29 @@ class JiraClientTest < ActiveSupport::TestCase
     ENV["JIRA_API_TOKEN"] = nil
     # No stub set — would raise if the method tried to make a request.
     assert_nil JiraClient.add_comment("ABC-1", "hello")
+  end
+
+  test "update_story_points PUTs the discovered field with a numeric value" do
+    Rails.cache.write("jira:issue:ABC-1", JiraClient::Result.new(found: true, story_points_field_id: "customfield_10016"))
+    captured = nil
+    stub_http_response(Net::HTTPSuccess, body: "{}", capture: ->(req) { captured = req }) do
+      JiraClient.update_story_points("ABC-1", 5)
+    end
+    assert_equal "PUT", captured.method
+    assert_match %r{/rest/api/3/issue/ABC-1$}, captured.path
+    assert_equal "application/json", captured["Content-Type"]
+    assert_equal({ "fields" => { "customfield_10016" => 5.0 } }, JSON.parse(captured.body))
+  end
+
+  test "update_story_points is a no-op when the story points field cannot be discovered" do
+    Rails.cache.write("jira:issue:ABC-1", JiraClient::Result.new(found: true, story_points_field_id: nil))
+    # No stub set — would raise if a request fired.
+    assert_nil JiraClient.update_story_points("ABC-1", 5)
+  end
+
+  test "update_story_points is a no-op when not configured" do
+    ENV["JIRA_API_TOKEN"] = nil
+    assert_nil JiraClient.update_story_points("ABC-1", 5)
   end
 
   private


### PR DESCRIPTION
## Summary
- When **Accept Estimate** is clicked, the accepted value is now also written to the Jira ticket's **Story Points** field via `PUT /rest/api/3/issue/{key}`.
- Field ID is auto-discovered via the existing `expand=names` lookup. Matches both classic "Story Points" and the newer "Story point estimate" name.
- Falls back gracefully — if Jira isn't configured, or the field can't be discovered, the controller still completes normally (the local estimate is still saved, comment is still posted) and a warning is logged.

## Implementation
- `JiraClient::Result` gains `story_points_field_id`.
- `JiraClient.update_story_points(issue_key, points)` — uses the cached `issue(key)` lookup to find the field ID, then PUTs the new value. PUT support added to `perform_request`.
- `StoriesController#accept_estimate` calls `update_story_points` right after the local `update!(status: 'estimated', estimate: …)`.

## Test plan
- [x] `bin/rails test test/lib` — 22/22 passing (4 new tests: discovery under both field names; PUT shape; no-op when field missing; no-op when unconfigured).
- [ ] Manual: with `JIRA_API_URL` / `JIRA_EMAIL` / `JIRA_API_TOKEN` set, run a planning session, click Accept Estimate, confirm the Story Points field on the Jira ticket now reflects the accepted value.
- [ ] Manual: try a ticket type that doesn't expose Story Points — verify Accept Estimate still completes, no 500.